### PR TITLE
fix: fix a potential error when the class of theme toolbar is injected with any other class by some browser plugins.

### DIFF
--- a/public/javascripts/chart-list.js
+++ b/public/javascripts/chart-list.js
@@ -99,7 +99,7 @@ if (params.theme === 'dark') {
 $('#theme a').popover({
     html: true,
     content: function () {
-        var theme = $(this).data('original-title').trim();
+        var theme = $(this).data('theme');
         return '<div class="theme-palette ' + theme + '">'
             + COLORS[theme].map(function (color) {
                 return '<span style="background-color:' + color + '"></span>'

--- a/public/javascripts/chart-list.js
+++ b/public/javascripts/chart-list.js
@@ -99,7 +99,7 @@ if (params.theme === 'dark') {
 $('#theme a').popover({
     html: true,
     content: function () {
-        var theme = $(this).attr('class').replace('selected', '').trim();
+        var theme = $(this).data('original-title').trim();
         return '<div class="theme-palette ' + theme + '">'
             + COLORS[theme].map(function (color) {
                 return '<span style="background-color:' + color + '"></span>'

--- a/views/index.jade
+++ b/views/index.jade
@@ -9,11 +9,11 @@ block inner_content
         #toolbar
             #theme
                 span Theme:
-                a(href="./index.html" title="default" class="default")
+                a(href="./index.html" title="default" data-theme="default" class="default")
                     span
-                a(href="./index.html?theme=light" title="light" class="light")
+                a(href="./index.html?theme=light" title="light" data-theme="light" class="light")
                     span
-                a(href="./index.html?theme=dark" title="dark" class="dark")
+                a(href="./index.html?theme=dark" title="dark" data-theme="dark" class="dark")
                     span
 
         .chart-list-panel


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26999792/88243183-208c2a80-ccc2-11ea-91b6-50845cf7ffda.png)

![image](https://user-images.githubusercontent.com/26999792/88244024-f12aed00-ccc4-11ea-89dc-739aca4edd7e.png)


This error may be thrown when the browser installed some extension plugins, as it is shown in the screenshot above. Those plugins may inject some extra classes for their own work. In this case, the current logic to fetch the theme name from class names is not enough exact. A suggested change has been listed below.

**Before**
```js
var theme = $(this).attr('class').replace('selected', '').trim();
```

**Changes**
```js
var theme = $(this).data('theme');
```

I've tried to use a data attribute named `data-theme` as the theme name and I'm sure it won't be modified by those plugins.

![image](https://user-images.githubusercontent.com/26999792/88243602-7ca37e80-ccc3-11ea-9353-f399f72bf797.png)

