### PR TITLE
fix(scripts): `dev` script cannot run successfully on Windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "watch": "npx webpack --config build/webpack.config.js --mode development --devtool sourcemap --watch",
     "localsite": "npm run build && node build/copyResource.js --env localsite",
     "release": "npm run build && node build/copyResource.js --env asf",
-    "dev": "npx concurrently --kill-others \"npm run watch\" \"node build/server.js\"",
-    "build:example": "node tool/build-example.js"
+    "dev": "npx concurrently --kill-others \"npm:watch\" \"npm:server\"",
+    "build:example": "node tool/build-example.js",
+    "server": "node build/server.js"
   },
   "devDependencies": {
     "@babel/core": "^7.10.2",


### PR DESCRIPTION
When I run the command `npm run dev` on Windows, the terminal will throw some errors.

```shell
> npx concurrently --kill-others "npm run watch" "node build/server.js"

[1] 'run' �����ڲ����ⲿ���Ҳ���ǿ����еĳ���
[1] ���������ļ���
[2] 'watch' �����ڲ����ⲿ���Ҳ���ǿ����еĳ���
[2] ���������ļ���
[4] 'build' �����ڲ����ⲿ���Ҳ���ǿ����еĳ���
[4] ���������ļ���
[2] watch exited with code 1
--> Sending SIGTERM to other processes..
[1] run exited with code 1
--> Sending SIGTERM to other processes..
[4] build/server.js exited with code 1
--> Sending SIGTERM to other processes..
[0]
[0] Usage: npm <command>
[0]
[0] where <command> is one of:
[0]     access, adduser, audit, bin, bugs, c, cache, ci, cit,
[0]     clean-install, clean-install-test, completion, config,
[0]     create, ddp, dedupe, deprecate, dist-tag, docs, doctor,
[0]     edit, explore, fund, get, help, help-search, hook, i, init,
[0]     install, install-ci-test, install-test, it, link, list, ln,
[0]     login, logout, ls, org, outdated, owner, pack, ping, prefix,
[0]     profile, prune, publish, rb, rebuild, repo, restart, root,
[0]     run, run-script, s, se, search, set, shrinkwrap, star,
[0]     stars, start, stop, t, team, test, token, tst, un,
[0]     uninstall, unpublish, unstar, up, update, v, version, view,
[0]     whoami
[0]
[0] npm <command> -h  quick help on <command>
[0] npm -l            display full usage info
[0] npm help <term>   search for help on <term>
[0] npm help npm      involved overview
```

This may be a compatibility issue of `concurrently`, thus I made two changes to the `dev` script as follows:

**(1) Replace the spaces in the command string with `':'`**

`npm run watch` -> `npm:watch` (shortened)

**(2) Move `node build/server.js` to a new separate script `server`**

`"server": "node build/server.js"`

As the above changes, the final script for `dev` will be:

```shell
npx concurrently --kill-others \"npm:watch\" \"npm:server\"
```

I've made some tests in Mac OS and Windows, the results are OK.
