### PR TITLE
fix(gl): fix some examples depends on bmap can't work.

### DIFF
--- a/src/data/chart-list-data-gl.js
+++ b/src/data/chart-list-data-gl.js
@@ -129,7 +129,9 @@ export default [
       "flowGL"
     ],
     "id": "global-wind-visualization",
-    "tags": [],
+    "tags": [
+      "bmap"
+    ],
     "title": "Global wind visualization",
     "titleCN": "Global wind visualization",
     "difficulty": 10
@@ -139,7 +141,9 @@ export default [
       "flowGL"
     ],
     "id": "global-wind-visualization-2",
-    "tags": [],
+    "tags": [
+      "bmap"
+    ],
     "title": "Global Wind Visualization 2",
     "titleCN": "Global Wind Visualization 2",
     "difficulty": 10

--- a/src/editor/Preview.vue
+++ b/src/editor/Preview.vue
@@ -4,7 +4,9 @@
         class="right-panel"
         id="chart-panel"
         :style="{background: backgroundColor}"
-    ></div>
+    >
+        <div class="chart-container"></div>
+    </div>
     <div id="tool-panel">
         <div class="left-panel">
             <el-switch
@@ -109,7 +111,7 @@ export function ensureECharts() {
             SCRIPT_URLS.echartsStatMinJS,
             ...URL_PARAMS.gl ? [SCRIPT_URLS.echartsGLMinJS] : [],
             ...hasBmap ? [
-                'https://api.map.baidu.com/getscript?v=2.0&ak=KOmVjPVUAey1G2E8zNhPiuQ6QiEmAwZu&services=&t=20200327103013',
+                'https://api.map.baidu.com/getscript?v=3.0&ak=KOmVjPVUAey1G2E8zNhPiuQ6QiEmAwZu&services=&t=20200327103013',
                 SCRIPT_URLS.echartsDir + '/dist/extension/bmap.js'
             ] : []
         ]).then(() => {
@@ -147,7 +149,7 @@ function run() {
     }
 
     try {
-        const updateTime = this.sandbox.run(this.$el.querySelector('#chart-panel'), store);
+        const updateTime = this.sandbox.run(this.$el.querySelector('.chart-container'), store);
 
         log(this.$t('editor.chartOK') + updateTime + 'ms');
 
@@ -321,6 +323,11 @@ export default {
             background-color: rgba(255, 0, 0, 0.2)!important;
             border: 1px solid red!important;
         }
+    }
+
+    .chart-container {
+        position: relative;
+        height: 100%;
     }
 }
 


### PR DESCRIPTION
**1) fix some examples depends on bmap can't work.**

Fix apache/echarts#14731

Broken examples:
- https://echarts.apache.org/examples/zh/editor.html?c=global-wind-visualization&gl=1
- https://echarts.apache.org/examples/zh/editor.html?c=global-wind-visualization-2&gl=1

**2) fix chart panel has no right and bottom padding.**

**Before**

<img src="https://user-images.githubusercontent.com/26999792/115530575-7b40ca00-a2c6-11eb-8387-26ece68eff24.png" width="400">

**After**

<img src="https://user-images.githubusercontent.com/26999792/115530686-93b0e480-a2c6-11eb-9c8f-7ef9812b6368.png" width="400">

**3) update BMap API version to v3.0**

This upgrade allows the user to use `mapStyleV2` in bmap.
It is also compatible with v2.0. I think it won't have any bad effects.