### PR TITLE
Show correct label for waterfall bar chart

### DIFF
--- a/public/examples/ts/bar-waterfall2.ts
+++ b/public/examples/ts/bar-waterfall2.ts
@@ -19,7 +19,7 @@ option = {
       if (params[1].value !== '-') {
         tar = params[1];
       } else {
-        tar = params[0];
+        tar = params[2];
       }
       return tar.name + '<br/>' + tar.seriesName + ' : ' + tar.value;
     }


### PR DESCRIPTION
Was incorrectly showing placeholder instead of expenses

Live Example 
![image](https://user-images.githubusercontent.com/536678/201867730-60720825-169b-4449-b7bc-0d678f5b07be.png)

Fixed
![image](https://user-images.githubusercontent.com/536678/201867787-c4d36d05-bbb1-4240-b883-d51da18ab02b.png)
