### PR TITLE
fix: flame chart

### DIFF
--- a/public/examples/ts/flame-graph.ts
+++ b/public/examples/ts/flame-graph.ts
@@ -221,7 +221,7 @@ $.get(
           type: 'custom',
           renderItem,
           encode: {
-            x: [0, 1],
+            x: [0, 1, 2],
             y: 0
           },
           data: recursionJson(stackTrace)


### PR DESCRIPTION
Flame chart layout get broken (the graph gets overflow) with small data reported in https://github.com/apache/echarts-examples/pull/71#issuecomment-1682739845. 

This PR is the fix