### PR TITLE
keep examples canvas centered inside container

### DIFF
--- a/src/editor/sandbox/srcdoc.html
+++ b/src/editor/sandbox/srcdoc.html
@@ -16,6 +16,10 @@
         position: relative;
         height: 100vh;
         overflow: hidden;
+        /* keep content centered on resize: */
+        display:flex; 
+        justify-content:center; 
+        align-items:center;	
       }
       .ec-debug-dirty-rect {
         background-color: rgba(255, 0, 0, 0.2) !important;


### PR DESCRIPTION
Added ```display:flex; justify-content:center; align-items:center;``` to **#chart-container** in _example-bundle.js_.

Currently command ```myChart.resize({width: V, height: V});``` in Editor will show the chart non-centered:
![ezgif com-optimize](https://github.com/user-attachments/assets/ab27ae2f-efeb-489a-b926-8764f4cf043d)
After this proposed change, _resize_ display the chart in the center of the container:
![ezgif com-optimize (1)](https://github.com/user-attachments/assets/864a0a27-9404-4e69-9fae-9c858c1ac112)
In addition to looking better, it'll also provide **simple zooming** for charts which do not support it now - like pie, sunburst, gauge, radar, sankey, etc.
