### PR TITLE
 Align titles with node-Align values for clarity

### DIFF
--- a/public/examples/ts/sankey-nodeAlign-left.ts
+++ b/public/examples/ts/sankey-nodeAlign-left.ts
@@ -12,7 +12,7 @@ $.get(ROOT_PATH + '/data/asset/data/energy.json', function (data) {
   myChart.setOption(
     (option = {
       title: {
-        text: 'Node Align Right'
+        text: 'Node Align Left'
       },
       tooltip: {
         trigger: 'item',

--- a/public/examples/ts/sankey-nodeAlign-right.ts
+++ b/public/examples/ts/sankey-nodeAlign-right.ts
@@ -12,7 +12,7 @@ $.get(ROOT_PATH + '/data/asset/data/energy.json', function (data) {
   myChart.setOption(
     (option = {
       title: {
-        text: 'Node Align Left'
+        text: 'Node Align Right'
       },
       tooltip: {
         trigger: 'item',


### PR DESCRIPTION
 PR fixes the mismatch between the displayed chart titles and actual node alignment in the Sankey examples. The changes ensure that:

- `sankey-nodeAlign-left` now correctly shows the title "Node Align Right" and uses `nodeAlign: 'left'`.
- `sankey-nodeAlign-right` now correctly shows the title "Node Align Left" and uses `nodeAlign: 'right'`.

### Before

**sankey-nodeAlign-left**  
Title: "Node Align Right"  
Node alignment: `left`  

![Before Right](https://github.com/user-attachments/assets/faaf7562-6f08-4023-afd5-587c7fcde6cb)


**sankey-nodeAlign-right**  
Title: "Node Align Left"  
Node alignment: `right`  

![Before Left](https://github.com/user-attachments/assets/bcbe4691-2daa-4d43-b7be-bb5ba582c0a5)

---

### After

**sankey-nodeAlign-left**  
Title: "Node Align Left"  
Node alignment: `left`  

![Node](https://github.com/user-attachments/assets/6c73edce-7658-4d54-b7df-f11372a027b0)

**sankey-nodeAlign-right**  
Title: "Node Align Right"  
Node alignment: `right`  

![Alignment](https://github.com/user-attachments/assets/f79a43dd-29ea-4ea5-87dd-f13d9435f682)


### Changes Made
- Updated metadata `title` fields in `public/examples/ts/sankey-nodeAlign-left.ts` and `public/examples/ts/sankey-nodeAlign-right.ts`.
- Verified alignment visually in the local dev environment.

This change improves **clarity and accuracy** for anyone using these examples as reference for Sankey layouts.
