### PR TITLE
Fix overlapping  in Speed Gauge

### DIFF
--- a/public/examples/ts/gauge-speed.ts
+++ b/public/examples/ts/gauge-speed.ts
@@ -80,7 +80,7 @@ option = {
             color: '#777'
           },
           unit: {
-            fontSize: 14,
+            fontSize: 20,
             color: '#999',
             padding: [0, 0, 0, 3]
           }

--- a/public/examples/ts/gauge-speed.ts
+++ b/public/examples/ts/gauge-speed.ts
@@ -24,18 +24,18 @@ option = {
       progress: {
         show: true,
         roundCap: true,
-        width: 18
+        width: 10
       },
       pointer: {
         icon: 'path://M2090.36389,615.30999 L2090.36389,615.30999 C2091.48372,615.30999 2092.40383,616.194028 2092.44859,617.312956 L2096.90698,728.755929 C2097.05155,732.369577 2094.2393,735.416212 2090.62566,735.56078 C2090.53845,735.564269 2090.45117,735.566014 2090.36389,735.566014 L2090.36389,735.566014 C2086.74736,735.566014 2083.81557,732.63423 2083.81557,729.017692 C2083.81557,728.930412 2083.81732,728.84314 2083.82081,728.755929 L2088.2792,617.312956 C2088.32396,616.194028 2089.24407,615.30999 2090.36389,615.30999 Z',
-        length: '75%',
-        width: 16,
+        length: '73%',
+        width: 10,
         offsetCenter: [0, '5%']
       },
       axisLine: {
         roundCap: true,
         lineStyle: {
-          width: 18
+          width: 10
         }
       },
       axisTick: {
@@ -53,9 +53,9 @@ option = {
         }
       },
       axisLabel: {
-        distance: 30,
+        distance: 16,
         color: '#999',
-        fontSize: 20
+        fontSize: 10
       },
       title: {
         show: false
@@ -64,9 +64,9 @@ option = {
         backgroundColor: '#fff',
         borderColor: '#999',
         borderWidth: 2,
-        width: '60%',
+        width: '50%',
         lineHeight: 40,
-        height: 40,
+        height: 36,
         borderRadius: 8,
         offsetCenter: [0, '35%'],
         valueAnimation: true,
@@ -75,14 +75,14 @@ option = {
         },
         rich: {
           value: {
-            fontSize: 50,
+            fontSize: 26,
             fontWeight: 'bolder',
             color: '#777'
           },
           unit: {
-            fontSize: 20,
+            fontSize: 14,
             color: '#999',
-            padding: [0, 0, -20, 10]
+            padding: [0, 0, 0, 3]
           }
         }
       },


### PR DESCRIPTION
This PR fixes an issue where the detail text (value and unit) in the Speed Gauge example overlaps with the pointer or gauge frame, especially for larger values.

Steps:
. Analyzed the issue in gauge-speed.ts to identify why the detail text overlaps with the pointer.
. Raised an https://github.com/apache/echarts-examples/issues/135
to track the problem.

Changes made:
. Adjusted detail.offsetCenter to improve vertical spacing
. Refined rich.value and rich.unit styles for better alignment
. Ensured the text remains centered and readable across all values
. Also i revert the changes 
. Fixing the Bug of Thumbnail 
. Now Thunmbail and commits are updated By applying this command: node tool/build-example.js --pattern gauge-speed


