### PR TITLE
Fix Sankey  alignment to better match thumbnail preview

### DIFF
--- a/public/examples/ts/sankey-itemstyle.ts
+++ b/public/examples/ts/sankey-itemstyle.ts
@@ -15,7 +15,7 @@ option = {
     {
       type: 'sankey',
       left: 50.0,
-      top: 20.0,
+      top: -140.0,
       right: 150.0,
       bottom: 25.0,
       data: [
@@ -1271,7 +1271,7 @@ option = {
       label: {
         color: 'rgba(0,0,0,0.7)',
         fontFamily: 'Arial',
-        fontSize: 10
+        fontSize: 7
       }
     }
   ],


### PR DESCRIPTION
Issue: [21271](https://github.com/apache/echarts/issues/21271)

Background:
While reviewing the Sankey diagram alignment discussed in the issue,
I explored how vertical centering affects the visual consistency between the example page and its thumbnail preview.

Before sankey:
                                Full size sankey 
[sankey-itemstyle (18).html](https://github.com/user-attachments/files/25213744/sankey-itemstyle.18.html)

![before sankey ](https://github.com/user-attachments/assets/dfdae8ca-b532-4691-aafe-3fd2afc97848)

centered sankey :
                                centered full size sankey 
[sankey-itemstyle (19).html](https://github.com/user-attachments/files/25213780/sankey-itemstyle.19.html)

![centered sankey](https://github.com/user-attachments/assets/a2ab0496-edb7-41db-953e-b3b1b73b4bc2)

If the Sankey nodes are forced to be exactly centered in the page, it creates two problems:
=> The layout does not match the thumbnail image preview.
=> Visual consistency between the example gallery thumbnail and the opened chart view is lost.
Because of this mismatch, strict page-level centering may not provide the best user experience.

Thumbnail matches sankey:
![sankey matches with thumbnail](https://github.com/user-attachments/assets/45ea4c60-04c3-47c7-988d-002590e6a9df)

This update keeps the Sankey alignment behavior that:
=> Matches the thumbnail preview more accurately
=> Maintains visual consistency across the examples gallery
=> Avoids unnecessary forced centering that could break expected layout appearance

Thumbnail according Sankey matches with last one images as u can clear see 
For the Sankey example context, this approach provides a more practical and visually aligned result than strict page centering.


