### PR TITLE
fix(editor): restore PR preview bundle routing

### DIFF
--- a/src/editor/Preview.vue
+++ b/src/editor/Preview.vue
@@ -186,13 +186,11 @@ function getScripts(nightly) {
         : 'echartsDir'
     ];
 
-  // TODO CSP 问题
-  // const echartsDir = store.isPR
-  //   ? echartsDirTpl.replace('{{PR_NUMBER}}', store.prNumber)
-  //   : echartsDirTpl.replace('{{version}}', store.echartsVersion);
   const echartsDir = isLocal
     ? SCRIPT_URLS.localEChartsDir
-    : SCRIPT_URLS.latestEChartsDir;
+    : store.isPR
+    ? echartsDirTpl.replace('{{PR_NUMBER}}', store.prNumber)
+    : echartsDirTpl.replace('{{version}}', store.echartsVersion);
 
   const code = store.runCode;
 


### PR DESCRIPTION
## Summary

This restores PR preview bundle routing in the examples editor.

The regression was introduced in `f7ad877` (`use cdn hosted in asf server to avoid csp issue`), where `getScripts()` started hardcoding `latestEChartsDir`. As a result, URLs like `?version=PR-21590@0c0f466` were still recognized as PR versions, but the editor loaded:

`/js/vendors/echarts/dist/echarts.min.js?_={commit}`

instead of switching to the preview host:

`https://echarts-pr-{PR_NUMBER}.surge.sh/dist/echarts.min.js`

This patch keeps the local behavior unchanged, while restoring the correct branch selection for PR preview and normal/nightly versioned bundles.

## Test

- `npm ci --legacy-peer-deps`
- `npm run build`
