### PR TITLE
fix: update Readme e2e setup  to require build:example

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Run all the examples to test package publishing and install, module importing, m
 Before run the tests. you need to update the examples list.
 
 ```shell
-npm run build:examplelist
+npm run build:example
 ```
 
 If puppeteer has not been installed:


### PR DESCRIPTION
## E2E Build Prerequisite Clarification
Following Readme instructions for e2e fails with error `You need to run node tool/build-example.js before run this test.`

### Problem

`echarts-examples` `README` instructs users to run:

```shell
npm run build:examplelist
```
so that e2e tests can execute without issues using 

```shell
npm run test:e2e:esbuild:local
```

However, `build:examplelist` invokes `tool/build-example.js --no-thumb`, which skips the Puppeteer-driven screenshot flow.

That also means the option JSON files under `public/data/option/*.json` are not generated, which invokes below code:

https://github.com/apache/echarts-examples/blob/37bf0264b9c37242a2ca59e2a50e3077b46f56c9/e2e/main.js#L280-L290

### Solution

- Update the README for proper e2e setup requiring  `npm run build:example`