### PR TITLE
feat: Add Navigation to Editor

### DIFF
--- a/src/common/exampleCatalogUtils.js
+++ b/src/common/exampleCatalogUtils.js
@@ -1,0 +1,143 @@
+import LazyLoad from 'vanilla-lazyload/dist/lazyload.esm';
+import { EXAMPLE_CATEGORIES, BLACK_MAP } from './config';
+
+const icons = {};
+[
+  'line',
+  'bar',
+  'scatter',
+  'pie',
+  'radar',
+  'funnel',
+  'gauge',
+  'map',
+  'graph',
+  'treemap',
+  'parallel',
+  'sankey',
+  'candlestick',
+  'boxplot',
+  'heatmap',
+  'pictorialBar',
+  'themeRiver',
+  'calendar',
+  'matrix',
+  'chord',
+  'custom',
+  'sunburst',
+  'tree',
+  'dataset',
+  'geo',
+  'lines',
+  'dataZoom',
+  'rich',
+  'graphic'
+].forEach(function (category) {
+  icons[category] = require('../asset/icon/' + category + '.svg');
+});
+
+const glIcon = require('../asset/icon/gl.svg');
+[
+  'globe',
+  'bar3D',
+  'scatter3D',
+  'surface',
+  'map3D',
+  'lines3D',
+  'line3D',
+  'scatterGL',
+  'linesGL',
+  'flowGL',
+  'graphGL',
+  'geo3D'
+].forEach(function (category) {
+  icons[category] = glIcon;
+});
+
+function defaultErrorCallback(img) {
+  const fallbackSrc = img.src;
+  const children = img.parentElement.children;
+  for (let i = 0, len = children.length; i < len; i++) {
+    const el = children[i];
+    if (el !== img) {
+      el.srcset = fallbackSrc;
+    }
+  }
+}
+
+export function createLazyLoader(options = {}) {
+  return new LazyLoad({
+    // Container should be the scroll viewport.
+    // container: this.$el.querySelector('#explore-container .example-list-panel')
+    elements_selector: '.chart-area',
+    load_delay: 400,
+    class_loaded: 'ec-shot-loaded',
+    callback_error: defaultErrorCallback,
+    ...options
+  });
+}
+
+function buildExampleListByCategory(chartList, chartListGL) {
+  const exampleListByCategory = {};
+
+  function addExamples(list, isGL) {
+    let categoryOrder = 0;
+
+    do {
+      let added = false;
+      for (let i = 0; i < list.length; i++) {
+        const example = list[i];
+        if (BLACK_MAP.hasOwnProperty(example.id)) {
+          continue;
+        }
+        if (example.noExplore) {
+          continue;
+        }
+        if (typeof example.category === 'string') {
+          example.category = [example.category];
+        }
+
+        const categoryStr = (example.category || [])[categoryOrder];
+        if (categoryStr) {
+          added = true;
+          let categoryObj = exampleListByCategory[categoryStr];
+          if (!categoryObj) {
+            categoryObj = {
+              category: categoryStr,
+              examples: []
+            };
+            exampleListByCategory[categoryStr] = categoryObj;
+          }
+          example.isGL = isGL;
+          categoryObj.examples.push(example);
+        }
+      }
+
+      if (!added) {
+        break;
+      }
+    } while (++categoryOrder && categoryOrder < 4);
+  }
+
+  addExamples(chartList, false);
+  addExamples(chartListGL, true);
+
+  return exampleListByCategory;
+}
+
+function createExampleList(exampleListByCategory) {
+  const list = [];
+  for (let i = 0, len = EXAMPLE_CATEGORIES.length; i < len; i++) {
+    const category = EXAMPLE_CATEGORIES[i];
+    const categoryObj = exampleListByCategory[category];
+    if (categoryObj && categoryObj.examples.length > 0) {
+      list.push({
+        category,
+        examples: categoryObj.examples
+      });
+    }
+  }
+  return list;
+}
+
+export { icons, buildExampleListByCategory, createExampleList };

--- a/src/editor/Editor.vue
+++ b/src/editor/Editor.vue
@@ -1,8 +1,6 @@
 <template>
   <section class="editor-workspace">
-    <nav class="editor-nav">
-      <Navigation />
-    </nav>
+    <Navigation @select-example="onSelectExample" :embedded="true" />
     <div id="main-container" :class="{ 'is-dragging': draggingMouseDown }">
       <div
         id="editor-left-container"
@@ -579,6 +577,68 @@ export default {
   },
 
   methods: {
+    syncURLParams(params) {
+      const url = new URL(location.href);
+      Object.entries(params).forEach(([key, val]) => {
+        if (val == null || val === false || val === '') {
+          delete URL_PARAMS[key];
+          url.searchParams.delete(key);
+        } else {
+          URL_PARAMS[key] = String(val);
+          url.searchParams.set(key, String(val));
+        }
+      });
+      history.pushState({}, '', url.toString());
+    },
+
+    loadCurrentExampleToEditor() {
+      loadExampleCode().then((code) => {
+        const parsedCode = parseSourceCode(code);
+        this.exampleConfig = getExampleConfig();
+
+        if (store.isMobile) {
+          store.runCode = parsedCode;
+          return;
+        }
+
+        this.initialCode = parsedCode;
+        store.initialCode = parsedCode;
+        this.$nextTick(() => this.disposeAndRun());
+      });
+    },
+
+    onSelectExample(example) {
+      if (!example || !example.id) return;
+
+      const hasCodeChanged =
+        this.initialCode &&
+        store.sourceCode &&
+        store.sourceCode !== this.initialCode;
+
+      const proceed = () => {
+        this.syncURLParams({
+          c: example.id,
+          gl: example.isGL ? 1 : null,
+          code: null,
+          enc: null
+        });
+        this.loadCurrentExampleToEditor();
+      };
+
+      if (!hasCodeChanged) {
+        proceed();
+        return;
+      }
+
+      this.$confirm(this.$t('editor.codeChangedConfirm'), '', {
+        confirmButtonText: this.$t('editor.confirmButtonText'),
+        cancelButtonText: this.$t('editor.cancelButtonText'),
+        type: 'warning'
+      })
+        .then(proceed)
+        .catch(() => {});
+    },
+
     toExternalEditor(vendor) {
       const previewRef = this.$refs.preview;
       if (!previewRef) {
@@ -880,11 +940,12 @@ $handler-width: 15px;
   > * {
     min-height: 0;
   }
-}
 
-.editor-nav {
-  overflow: auto;
-  height: 100%;
+  .editor-nav {
+    overflow: auto;
+    height: 100%;
+    width: 100%;
+  }
 }
 
 #main-container {

--- a/src/editor/Editor.vue
+++ b/src/editor/Editor.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="editor-workspace">
+  <article class="editor-workspace">
     <Navigation
       @select-example="onSelectExample"
       :currentExample="exampleConfig"
@@ -429,7 +429,7 @@
         }"
       ></Preview>
     </div>
-  </section>
+  </article>
 </template>
 
 <script>
@@ -937,17 +937,14 @@ $pd-basic: 10px;
 $handler-width: 15px;
 
 .editor-workspace {
-  display: grid;
-  grid-template-columns: 200px 1fr;
   height: 100vh;
   > * {
     min-height: 0;
   }
 
-  .editor-nav {
-    overflow: auto;
-    height: 100%;
-    width: 100%;
+  @media (min-width: 600px) {
+    display: grid;
+    grid-template-columns: 200px 1fr;
   }
 }
 

--- a/src/editor/Editor.vue
+++ b/src/editor/Editor.vue
@@ -1,417 +1,434 @@
 <template>
-  <div id="main-container" :class="{ 'is-dragging': draggingMouseDown }">
-    <div
-      id="editor-left-container"
-      :style="{ width: leftContainerSize + '%' }"
-      v-if="!shared.isMobile"
-    >
-      <el-tabs v-model="currentTab" type="border-card">
-        <el-tab-pane name="code-editor">
-          <span slot="label">{{ $t('editor.tabEditor') }}</span>
-          <el-container>
-            <el-header id="editor-control-panel">
-              <div>
-                <div class="languages">
-                  <el-tooltip
-                    :content="$t('editor.tooltip.jsMode')"
-                    placement="bottom"
-                  >
-                    <a
-                      :class="{ js: true, active: !shared.typeCheck }"
-                      @click="changeLang('js')"
-                      >JS</a
+  <section class="editor-workspace">
+    <nav class="editor-nav">
+      <Navigation />
+    </nav>
+    <div id="main-container" :class="{ 'is-dragging': draggingMouseDown }">
+      <div
+        id="editor-left-container"
+        :style="{ width: leftContainerSize + '%' }"
+        v-if="!shared.isMobile"
+      >
+        <el-tabs v-model="currentTab" type="border-card">
+          <el-tab-pane name="code-editor">
+            <span slot="label">{{ $t('editor.tabEditor') }}</span>
+            <el-container>
+              <el-header id="editor-control-panel">
+                <div>
+                  <div class="languages">
+                    <el-tooltip
+                      :content="$t('editor.tooltip.jsMode')"
+                      placement="bottom"
                     >
-                  </el-tooltip>
-                  <el-tooltip
-                    :content="$t(`editor.tooltip.${hasTs ? 'tsMode' : 'noTs'}`)"
-                    placement="bottom"
-                  >
-                    <a
-                      @click="hasTs && changeLang('ts')"
-                      :class="{
-                        ts: true,
-                        active: shared.typeCheck,
-                        disabled: !hasTs
-                      }"
-                      >TS</a
+                      <a
+                        :class="{ js: true, active: !shared.typeCheck }"
+                        @click="changeLang('js')"
+                        >JS</a
+                      >
+                    </el-tooltip>
+                    <el-tooltip
+                      :content="
+                        $t(`editor.tooltip.${hasTs ? 'tsMode' : 'noTs'}`)
+                      "
+                      placement="bottom"
                     >
-                  </el-tooltip>
+                      <a
+                        @click="hasTs && changeLang('ts')"
+                        :class="{
+                          ts: true,
+                          active: shared.typeCheck,
+                          disabled: !hasTs
+                        }"
+                        >TS</a
+                      >
+                    </el-tooltip>
+                  </div>
+                  <div class="example-version-since" v-if="hasVersionSince">
+                    {{ versionSinceBanner }}
+                  </div>
                 </div>
-                <div class="example-version-since" v-if="hasVersionSince">
-                  {{ versionSinceBanner }}
-                </div>
-              </div>
-              <div class="editor-controls">
-                <a
-                  v-if="shared.isPR"
-                  class="btn btn-default btn-sm pull-request"
-                  target="_blank"
-                  :href="`https://github.com/apache/echarts/pull/${shared.prNumber}`"
-                  :title="`${pr && pr.title ? pr.title + '\n' : ''}${$t(
-                    'editor.pr.tooltip'
-                  )}`"
-                >
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                    <path
-                      fill="currentColor"
-                      d="M12 2A10 10 0 0 0 2 12c0 4.42 2.87 8.17 6.84 9.5c.5.08.66-.23.66-.5v-1.69c-2.77.6-3.36-1.34-3.36-1.34c-.46-1.16-1.11-1.47-1.11-1.47c-.91-.62.07-.6.07-.6c1 .07 1.53 1.03 1.53 1.03c.87 1.52 2.34 1.07 2.91.83c.09-.65.35-1.09.63-1.34c-2.22-.25-4.55-1.11-4.55-4.92c0-1.11.38-2 1.03-2.71c-.1-.25-.45-1.29.1-2.64c0 0 .84-.27 2.75 1.02c.79-.22 1.65-.33 2.5-.33c.85 0 1.71.11 2.5.33c1.91-1.29 2.75-1.02 2.75-1.02c.55 1.35.2 2.39.1 2.64c.65.71 1.03 1.6 1.03 2.71c0 3.82-2.34 4.66-4.57 4.91c.36.31.69.92.69 1.85V21c0 .27.16.59.67.5C19.14 20.16 22 16.42 22 12A10 10 0 0 0 12 2Z"
-                    />
-                  </svg>
-                  <span>#{{ shared.prNumber }}</span>
-                </a>
-                <a
-                  class="btn btn-sm codepen"
-                  @click="toExternalEditor('CodePen')"
-                  :title="$t('editor.openWithCodePen')"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="none"
+                <div class="editor-controls">
+                  <a
+                    v-if="shared.isPR"
+                    class="btn btn-default btn-sm pull-request"
+                    target="_blank"
+                    :href="`https://github.com/apache/echarts/pull/${shared.prNumber}`"
+                    :title="`${pr && pr.title ? pr.title + '\n' : ''}${$t(
+                      'editor.pr.tooltip'
+                    )}`"
                   >
-                    <path
-                      d="M21.838 8.445c0-.001-.001-.001 0 0l-.003-.004l-.001-.001v-.001a.809.809 0 0 0-.235-.228l-9.164-6.08a.834.834 0 0 0-.898 0L2.371 8.214A.786.786 0 0 0 2 8.897v6.16a.789.789 0 0 0 .131.448v.001l.002.002l.01.015v.002h.001l.001.001l.001.001c.063.088.14.16.226.215l9.165 6.082a.787.787 0 0 0 .448.139a.784.784 0 0 0 .45-.139l9.165-6.082a.794.794 0 0 0 .371-.685v-6.16a.793.793 0 0 0-.133-.452zm-9.057-4.172l6.953 4.613l-3.183 2.112l-3.771-2.536V4.273zm-1.592 0v4.189l-3.771 2.536l-3.181-2.111l6.952-4.614zm-7.595 6.098l2.395 1.59l-2.395 1.611v-3.201zm7.595 9.311l-6.96-4.617l3.195-2.15l3.765 2.498v4.269zm.795-5.653l-3.128-2.078l3.128-2.105l3.131 2.105l-3.131 2.078zm.797 5.653v-4.27l3.766-2.498l3.193 2.15l-6.959 4.618zm7.597-6.11l-2.396-1.611l2.396-1.59v3.201z"
-                      fill="currentColor"
-                    ></path>
-                  </svg>
-                </a>
-                <a
-                  class="btn btn-sm codesandbox"
-                  @click="toExternalEditor('CodeSandbox')"
-                  :title="$t('editor.openWithCodeSandbox')"
-                >
-                  <svg
-                    viewBox="0 0 512 512"
-                    fill="none"
-                    stroke="currentColor"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M69 153.99L256 263.99M256 263.99L443 153.99M256 263.99V463.99M448 341.37V170.61C447.993 165.021 446.523 159.531 443.735 154.687C440.947 149.843 436.939 145.814 432.11 143L280.11 54.54C272.787 50.2765 264.464 48.0303 255.99 48.0303C247.516 48.0303 239.193 50.2765 231.87 54.54L79.89 143C75.0609 145.814 71.053 149.843 68.2652 154.687C65.4773 159.531 64.0068 165.021 64 170.61V341.37C64.0033 346.962 65.4722 352.456 68.2602 357.304C71.0482 362.152 75.058 366.185 79.89 369L231.89 457.46C239.215 461.718 247.537 463.96 256.01 463.96C264.483 463.96 272.805 461.718 280.13 457.46L432.13 369C436.958 366.182 440.964 362.148 443.748 357.301C446.533 352.453 447.999 346.96 448 341.37Z"
-                      stroke="currentColor"
-                      stroke-width="38"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    ></path>
-                  </svg>
-                </a>
-                <a
-                  class="btn btn-sm format"
-                  :title="$t('editor.format')"
-                  :disabled="!formatterReady"
-                  :style="{ cursor: formatterReady ? '' : 'progress' }"
-                  @click="format"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
-                    />
-                  </svg>
-                </a>
-                <a class="btn btn-default btn-sm run" @click="disposeAndRun">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
-                    />
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                    />
-                  </svg>
-                  <span>{{ $t('editor.run') }}</span>
-                </a>
-              </div>
-            </el-header>
-            <el-main>
-              <CodeMonaco
-                v-if="shared.typeCheck"
-                id="code-panel"
-                :initialCode="initialCode"
-                @ready="prepareFormatter"
-              />
-              <CodeAce v-else id="code-panel" :initialCode="initialCode" />
-            </el-main>
-          </el-container>
-        </el-tab-pane>
-
-        <el-tab-pane
-          :label="$t('editor.tabFullCodePreview')"
-          name="full-code"
-          :lazy="true"
-        >
-          <el-container style="width: 100%; height: 100%">
-            <el-header id="full-code-generate-config">
-              <span class="full-code-generate-config-label">
-                <!-- <i class="el-icon-setting"></i> 配置 -->
-              </span>
-              <el-switch
-                v-model="fullCodeConfig.minimal"
-                :active-text="$t('editor.minimalBundle')"
-                :inactive-text="''"
-              >
-              </el-switch>
-              <el-switch
-                v-if="!shared.typeCheck"
-                v-model="fullCodeConfig.esm"
-                active-text="ES Modules"
-                :inactive-text="''"
-              >
-              </el-switch>
-            </el-header>
-            <el-main>
-              <FullCodePreview :code="fullCode"></FullCodePreview>
-            </el-main>
-          </el-container>
-        </el-tab-pane>
-
-        <el-tab-pane :label="$t('editor.tabOptionPreview')" name="full-option">
-          <div id="option-outline" ref="optionOutline"></div>
-        </el-tab-pane>
-
-        <el-tab-pane
-          v-if="shared.isPR"
-          v-loading="isPRLoading"
-          :label="$t('editor.prPreview.title')"
-          name="pr-preview"
-        >
-          <div v-if="pr" id="pr-preview" ref="prPreview">
-            <el-descriptions
-              class="pr-info"
-              direction="vertical"
-              size="small"
-              :column="4"
-              border
-            >
-              <a
-                slot="title"
-                class="pr-title"
-                ref="prTitle"
-                target="_blank"
-                :href="pr.html_url"
-                >(#{{ pr.number }}) {{ pr.title }}</a
-              >
-              <el-descriptions-item :label="$t('editor.prPreview.author')">
-                <a
-                  target="_blank"
-                  :href="pr.user.html_url"
-                  class="pr-author-avatar"
-                >
-                  <el-avatar :src="pr.user.avatar_url" :size="20" />
-                  <span>{{ pr.user.login }}</span>
-                </a>
-              </el-descriptions-item>
-              <el-descriptions-item :label="$t('editor.prPreview.fromBranch')">
-                <a
-                  target="_blank"
-                  :href="pr.head.repo.html_url + '/tree/' + pr.head.ref"
-                  :title="pr.head.label"
-                >
-                  {{ pr.head.ref }}
-                </a>
-              </el-descriptions-item>
-              <el-descriptions-item :label="$t('editor.prPreview.toBranch')">
-                <a
-                  target="_blank"
-                  :href="pr.base.repo.html_url + '/tree/' + pr.base.ref"
-                  :title="pr.base.label"
-                >
-                  {{ pr.base.ref }}
-                </a>
-              </el-descriptions-item>
-              <el-descriptions-item :label="$t('editor.prPreview.milestone')">
-                <a
-                  v-if="pr.milestone"
-                  target="_blank"
-                  :href="pr.milestone.html_url"
-                >
-                  {{ pr.milestone.title }}
-                </a>
-                <template v-else>-</template>
-              </el-descriptions-item>
-              <el-descriptions-item
-                :label="$t('editor.prPreview.labels')"
-                :span="4"
-              >
-                <el-tag
-                  v-for="label in pr.labels"
-                  :key="label.id"
-                  size="small"
-                  class="pr-label"
-                  :color="'#' + label.color"
-                  :title="label.description"
-                  >{{ label.name }}</el-tag
-                >
-              </el-descriptions-item>
-              <el-descriptions-item
-                :label="$t('editor.prPreview.changes')"
-                :span="4"
-              >
-                <el-descriptions
-                  size="small"
-                  direction="vertical"
-                  :column="5"
-                  :colon="false"
-                >
-                  <el-descriptions-item
-                    :label="$t('editor.prPreview.addedLines')"
-                  >
-                    <span>
-                      {{ pr.additions }}
-                    </span>
-                  </el-descriptions-item>
-                  <el-descriptions-item
-                    :label="$t('editor.prPreview.removedLines')"
-                  >
-                    <span>
-                      {{ pr.deletions }}
-                    </span>
-                  </el-descriptions-item>
-                  <el-descriptions-item
-                    :label="$t('editor.prPreview.changedFiles')"
-                  >
-                    <a :href="pr.html_url + '/files'" target="_blank">
-                      {{ pr.changed_files }}
-                    </a>
-                  </el-descriptions-item>
-                  <el-descriptions-item :label="$t('editor.prPreview.commits')">
-                    <a :href="pr.html_url + '/commits'" target="_blank">
-                      {{ pr.commits }}
-                    </a>
-                  </el-descriptions-item>
-                  <el-descriptions-item
-                    :label="$t('editor.prPreview.latestCommit')"
-                  >
-                    <a
-                      :href="pr.html_url + '/commits/' + pr.head.sha"
-                      target="_blank"
-                    >
-                      {{ pr.head.sha.slice(0, 7) }}
-                    </a>
-                  </el-descriptions-item>
-                </el-descriptions>
-              </el-descriptions-item>
-              <el-descriptions-item :span="4">
-                <span slot="label">
-                  {{ $t('editor.prPreview.review') }}
-                  <i
-                    v-if="isPRReviewLoading"
-                    class="el-icon-loading"
-                    style="margin-left: 5px"
-                  ></i>
-                </span>
-                <span v-if="isPRReviewLoading">{{
-                  $t('editor.prPreview.loadingReview')
-                }}</span>
-                <span v-else-if="isPRReviewLoading === false">{{
-                  $t('editor.prPreview.reviewLoadFailed')
-                }}</span>
-                <span v-else-if="!prLatestReview">{{
-                  $t('editor.prPreview.noReview')
-                }}</span>
-                <el-descriptions
-                  v-else
-                  size="small"
-                  direction="vertical"
-                  :column="3"
-                  :colon="false"
-                >
-                  <el-descriptions-item
-                    :label="$t('editor.prPreview.reviewedBy')"
-                  >
-                    <a
-                      target="_blank"
-                      :href="prLatestReview.user.html_url"
-                      class="pr-author-avatar"
-                    >
-                      <el-avatar
-                        :src="prLatestReview.user.avatar_url"
-                        :size="20"
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                      <path
+                        fill="currentColor"
+                        d="M12 2A10 10 0 0 0 2 12c0 4.42 2.87 8.17 6.84 9.5c.5.08.66-.23.66-.5v-1.69c-2.77.6-3.36-1.34-3.36-1.34c-.46-1.16-1.11-1.47-1.11-1.47c-.91-.62.07-.6.07-.6c1 .07 1.53 1.03 1.53 1.03c.87 1.52 2.34 1.07 2.91.83c.09-.65.35-1.09.63-1.34c-2.22-.25-4.55-1.11-4.55-4.92c0-1.11.38-2 1.03-2.71c-.1-.25-.45-1.29.1-2.64c0 0 .84-.27 2.75 1.02c.79-.22 1.65-.33 2.5-.33c.85 0 1.71.11 2.5.33c1.91-1.29 2.75-1.02 2.75-1.02c.55 1.35.2 2.39.1 2.64c.65.71 1.03 1.6 1.03 2.71c0 3.82-2.34 4.66-4.57 4.91c.36.31.69.92.69 1.85V21c0 .27.16.59.67.5C19.14 20.16 22 16.42 22 12A10 10 0 0 0 12 2Z"
                       />
-                      <span>{{ prLatestReview.user.login }}</span>
-                    </a>
-                  </el-descriptions-item>
-                  <el-descriptions-item
-                    :label="$t('editor.prPreview.reviewedAt')"
+                    </svg>
+                    <span>#{{ shared.prNumber }}</span>
+                  </a>
+                  <a
+                    class="btn btn-sm codepen"
+                    @click="toExternalEditor('CodePen')"
+                    :title="$t('editor.openWithCodePen')"
                   >
-                    {{ new Date(prLatestReview.submitted_at).toLocaleString() }}
-                  </el-descriptions-item>
-                  <el-descriptions-item
-                    :label="$t('editor.prPreview.reviewState')"
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="none"
+                    >
+                      <path
+                        d="M21.838 8.445c0-.001-.001-.001 0 0l-.003-.004l-.001-.001v-.001a.809.809 0 0 0-.235-.228l-9.164-6.08a.834.834 0 0 0-.898 0L2.371 8.214A.786.786 0 0 0 2 8.897v6.16a.789.789 0 0 0 .131.448v.001l.002.002l.01.015v.002h.001l.001.001l.001.001c.063.088.14.16.226.215l9.165 6.082a.787.787 0 0 0 .448.139a.784.784 0 0 0 .45-.139l9.165-6.082a.794.794 0 0 0 .371-.685v-6.16a.793.793 0 0 0-.133-.452zm-9.057-4.172l6.953 4.613l-3.183 2.112l-3.771-2.536V4.273zm-1.592 0v4.189l-3.771 2.536l-3.181-2.111l6.952-4.614zm-7.595 6.098l2.395 1.59l-2.395 1.611v-3.201zm7.595 9.311l-6.96-4.617l3.195-2.15l3.765 2.498v4.269zm.795-5.653l-3.128-2.078l3.128-2.105l3.131 2.105l-3.131 2.078zm.797 5.653v-4.27l3.766-2.498l3.193 2.15l-6.959 4.618zm7.597-6.11l-2.396-1.611l2.396-1.59v3.201z"
+                        fill="currentColor"
+                      ></path>
+                    </svg>
+                  </a>
+                  <a
+                    class="btn btn-sm codesandbox"
+                    @click="toExternalEditor('CodeSandbox')"
+                    :title="$t('editor.openWithCodeSandbox')"
                   >
-                    {{ prLatestReview.state }}
-                  </el-descriptions-item>
-                  <el-descriptions-item
-                    :label="$t('editor.prPreview.reviewComment')"
-                    :span="3"
+                    <svg
+                      viewBox="0 0 512 512"
+                      fill="none"
+                      stroke="currentColor"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M69 153.99L256 263.99M256 263.99L443 153.99M256 263.99V463.99M448 341.37V170.61C447.993 165.021 446.523 159.531 443.735 154.687C440.947 149.843 436.939 145.814 432.11 143L280.11 54.54C272.787 50.2765 264.464 48.0303 255.99 48.0303C247.516 48.0303 239.193 50.2765 231.87 54.54L79.89 143C75.0609 145.814 71.053 149.843 68.2652 154.687C65.4773 159.531 64.0068 165.021 64 170.61V341.37C64.0033 346.962 65.4722 352.456 68.2602 357.304C71.0482 362.152 75.058 366.185 79.89 369L231.89 457.46C239.215 461.718 247.537 463.96 256.01 463.96C264.483 463.96 272.805 461.718 280.13 457.46L432.13 369C436.958 366.182 440.964 362.148 443.748 357.301C446.533 352.453 447.999 346.96 448 341.37Z"
+                        stroke="currentColor"
+                        stroke-width="38"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      ></path>
+                    </svg>
+                  </a>
+                  <a
+                    class="btn btn-sm format"
+                    :title="$t('editor.format')"
+                    :disabled="!formatterReady"
+                    :style="{ cursor: formatterReady ? '' : 'progress' }"
+                    @click="format"
                   >
-                    <a :href="prLatestReview.html_url" target="_blank">
-                      {{
-                        prLatestReview.body || $t('editor.prPreview.noComment')
-                      }}
-                    </a>
-                  </el-descriptions-item>
-                </el-descriptions>
-              </el-descriptions-item>
-              <el-descriptions-item
-                :label="$t('editor.prPreview.diff')"
-                :span="4"
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
+                      />
+                    </svg>
+                  </a>
+                  <a class="btn btn-default btn-sm run" @click="disposeAndRun">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
+                      />
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                      />
+                    </svg>
+                    <span>{{ $t('editor.run') }}</span>
+                  </a>
+                </div>
+              </el-header>
+              <el-main>
+                <CodeMonaco
+                  v-if="shared.typeCheck"
+                  id="code-panel"
+                  :initialCode="initialCode"
+                  @ready="prepareFormatter"
+                />
+                <CodeAce v-else id="code-panel" :initialCode="initialCode" />
+              </el-main>
+            </el-container>
+          </el-tab-pane>
+
+          <el-tab-pane
+            :label="$t('editor.tabFullCodePreview')"
+            name="full-code"
+            :lazy="true"
+          >
+            <el-container style="width: 100%; height: 100%">
+              <el-header id="full-code-generate-config">
+                <span class="full-code-generate-config-label">
+                  <!-- <i class="el-icon-setting"></i> 配置 -->
+                </span>
+                <el-switch
+                  v-model="fullCodeConfig.minimal"
+                  :active-text="$t('editor.minimalBundle')"
+                  :inactive-text="''"
+                >
+                </el-switch>
+                <el-switch
+                  v-if="!shared.typeCheck"
+                  v-model="fullCodeConfig.esm"
+                  active-text="ES Modules"
+                  :inactive-text="''"
+                >
+                </el-switch>
+              </el-header>
+              <el-main>
+                <FullCodePreview :code="fullCode"></FullCodePreview>
+              </el-main>
+            </el-container>
+          </el-tab-pane>
+
+          <el-tab-pane
+            :label="$t('editor.tabOptionPreview')"
+            name="full-option"
+          >
+            <div id="option-outline" ref="optionOutline"></div>
+          </el-tab-pane>
+
+          <el-tab-pane
+            v-if="shared.isPR"
+            v-loading="isPRLoading"
+            :label="$t('editor.prPreview.title')"
+            name="pr-preview"
+          >
+            <div v-if="pr" id="pr-preview" ref="prPreview">
+              <el-descriptions
+                class="pr-info"
+                direction="vertical"
+                size="small"
+                :column="4"
+                border
               >
-                <details @toggle="$event.target.open && loadPRDiff()">
-                  <summary style="display: revert; cursor: pointer">
-                    {{ $t('editor.prPreview.viewDiff') }}
+                <a
+                  slot="title"
+                  class="pr-title"
+                  ref="prTitle"
+                  target="_blank"
+                  :href="pr.html_url"
+                  >(#{{ pr.number }}) {{ pr.title }}</a
+                >
+                <el-descriptions-item :label="$t('editor.prPreview.author')">
+                  <a
+                    target="_blank"
+                    :href="pr.user.html_url"
+                    class="pr-author-avatar"
+                  >
+                    <el-avatar :src="pr.user.avatar_url" :size="20" />
+                    <span>{{ pr.user.login }}</span>
+                  </a>
+                </el-descriptions-item>
+                <el-descriptions-item
+                  :label="$t('editor.prPreview.fromBranch')"
+                >
+                  <a
+                    target="_blank"
+                    :href="pr.head.repo.html_url + '/tree/' + pr.head.ref"
+                    :title="pr.head.label"
+                  >
+                    {{ pr.head.ref }}
+                  </a>
+                </el-descriptions-item>
+                <el-descriptions-item :label="$t('editor.prPreview.toBranch')">
+                  <a
+                    target="_blank"
+                    :href="pr.base.repo.html_url + '/tree/' + pr.base.ref"
+                    :title="pr.base.label"
+                  >
+                    {{ pr.base.ref }}
+                  </a>
+                </el-descriptions-item>
+                <el-descriptions-item :label="$t('editor.prPreview.milestone')">
+                  <a
+                    v-if="pr.milestone"
+                    target="_blank"
+                    :href="pr.milestone.html_url"
+                  >
+                    {{ pr.milestone.title }}
+                  </a>
+                  <template v-else>-</template>
+                </el-descriptions-item>
+                <el-descriptions-item
+                  :label="$t('editor.prPreview.labels')"
+                  :span="4"
+                >
+                  <el-tag
+                    v-for="label in pr.labels"
+                    :key="label.id"
+                    size="small"
+                    class="pr-label"
+                    :color="'#' + label.color"
+                    :title="label.description"
+                    >{{ label.name }}</el-tag
+                  >
+                </el-descriptions-item>
+                <el-descriptions-item
+                  :label="$t('editor.prPreview.changes')"
+                  :span="4"
+                >
+                  <el-descriptions
+                    size="small"
+                    direction="vertical"
+                    :column="5"
+                    :colon="false"
+                  >
+                    <el-descriptions-item
+                      :label="$t('editor.prPreview.addedLines')"
+                    >
+                      <span>
+                        {{ pr.additions }}
+                      </span>
+                    </el-descriptions-item>
+                    <el-descriptions-item
+                      :label="$t('editor.prPreview.removedLines')"
+                    >
+                      <span>
+                        {{ pr.deletions }}
+                      </span>
+                    </el-descriptions-item>
+                    <el-descriptions-item
+                      :label="$t('editor.prPreview.changedFiles')"
+                    >
+                      <a :href="pr.html_url + '/files'" target="_blank">
+                        {{ pr.changed_files }}
+                      </a>
+                    </el-descriptions-item>
+                    <el-descriptions-item
+                      :label="$t('editor.prPreview.commits')"
+                    >
+                      <a :href="pr.html_url + '/commits'" target="_blank">
+                        {{ pr.commits }}
+                      </a>
+                    </el-descriptions-item>
+                    <el-descriptions-item
+                      :label="$t('editor.prPreview.latestCommit')"
+                    >
+                      <a
+                        :href="pr.html_url + '/commits/' + pr.head.sha"
+                        target="_blank"
+                      >
+                        {{ pr.head.sha.slice(0, 7) }}
+                      </a>
+                    </el-descriptions-item>
+                  </el-descriptions>
+                </el-descriptions-item>
+                <el-descriptions-item :span="4">
+                  <span slot="label">
+                    {{ $t('editor.prPreview.review') }}
                     <i
-                      v-if="isPRDiffLoading"
+                      v-if="isPRReviewLoading"
                       class="el-icon-loading"
                       style="margin-left: 5px"
                     ></i>
-                  </summary>
-                  <pre
-                    class="pr-diff"
-                  ><span v-if="isPRDiffLoading">{{ $t('editor.prPreview.loadingDiff') }}</span><span v-if="isPRDiffLoading === false">{{ $t('editor.prPreview.diffLoadFailed') }}</span><div ref="prDiff"></div></pre>
-                </details>
-              </el-descriptions-item>
-            </el-descriptions>
-          </div>
-        </el-tab-pane>
-      </el-tabs>
+                  </span>
+                  <span v-if="isPRReviewLoading">{{
+                    $t('editor.prPreview.loadingReview')
+                  }}</span>
+                  <span v-else-if="isPRReviewLoading === false">{{
+                    $t('editor.prPreview.reviewLoadFailed')
+                  }}</span>
+                  <span v-else-if="!prLatestReview">{{
+                    $t('editor.prPreview.noReview')
+                  }}</span>
+                  <el-descriptions
+                    v-else
+                    size="small"
+                    direction="vertical"
+                    :column="3"
+                    :colon="false"
+                  >
+                    <el-descriptions-item
+                      :label="$t('editor.prPreview.reviewedBy')"
+                    >
+                      <a
+                        target="_blank"
+                        :href="prLatestReview.user.html_url"
+                        class="pr-author-avatar"
+                      >
+                        <el-avatar
+                          :src="prLatestReview.user.avatar_url"
+                          :size="20"
+                        />
+                        <span>{{ prLatestReview.user.login }}</span>
+                      </a>
+                    </el-descriptions-item>
+                    <el-descriptions-item
+                      :label="$t('editor.prPreview.reviewedAt')"
+                    >
+                      {{
+                        new Date(prLatestReview.submitted_at).toLocaleString()
+                      }}
+                    </el-descriptions-item>
+                    <el-descriptions-item
+                      :label="$t('editor.prPreview.reviewState')"
+                    >
+                      {{ prLatestReview.state }}
+                    </el-descriptions-item>
+                    <el-descriptions-item
+                      :label="$t('editor.prPreview.reviewComment')"
+                      :span="3"
+                    >
+                      <a :href="prLatestReview.html_url" target="_blank">
+                        {{
+                          prLatestReview.body ||
+                          $t('editor.prPreview.noComment')
+                        }}
+                      </a>
+                    </el-descriptions-item>
+                  </el-descriptions>
+                </el-descriptions-item>
+                <el-descriptions-item
+                  :label="$t('editor.prPreview.diff')"
+                  :span="4"
+                >
+                  <details @toggle="$event.target.open && loadPRDiff()">
+                    <summary style="display: revert; cursor: pointer">
+                      {{ $t('editor.prPreview.viewDiff') }}
+                      <i
+                        v-if="isPRDiffLoading"
+                        class="el-icon-loading"
+                        style="margin-left: 5px"
+                      ></i>
+                    </summary>
+                    <pre
+                      class="pr-diff"
+                    ><span v-if="isPRDiffLoading">{{ $t('editor.prPreview.loadingDiff') }}</span><span v-if="isPRDiffLoading === false">{{ $t('editor.prPreview.diffLoadFailed') }}</span><div ref="prDiff"></div></pre>
+                  </details>
+                </el-descriptions-item>
+              </el-descriptions>
+            </div>
+          </el-tab-pane>
+        </el-tabs>
+      </div>
+      <div
+        class="handler"
+        id="h-handler"
+        @mousedown="draggingMouseDown = true"
+        :style="{ left: leftContainerSize + '%' }"
+        v-if="!shared.isMobile"
+      ></div>
+      <Preview
+        :inEditor="true"
+        @ready="onPreviewReady"
+        class="right-container"
+        ref="preview"
+        :style="{
+          width: 100 - leftContainerSize + '%',
+          left: leftContainerSize + '%'
+        }"
+      ></Preview>
     </div>
-    <div
-      class="handler"
-      id="h-handler"
-      @mousedown="draggingMouseDown = true"
-      :style="{ left: leftContainerSize + '%' }"
-      v-if="!shared.isMobile"
-    ></div>
-    <Preview
-      :inEditor="true"
-      @ready="onPreviewReady"
-      class="right-container"
-      ref="preview"
-      :style="{
-        width: 100 - leftContainerSize + '%',
-        left: leftContainerSize + '%'
-      }"
-    ></Preview>
-  </div>
+  </section>
 </template>
 
 <script>
@@ -436,13 +453,15 @@ import { getScriptURLs, URL_PARAMS } from '../common/config';
 import { formatCode, loadScriptsAsync } from '../common/helper';
 import openWithCodePen from './sandbox/openwith/codepen';
 import openWithCodeSandbox from './sandbox/openwith/codesandbox';
+import Navigation from './Navigation.vue';
 
 export default {
   components: {
     CodeAce,
     CodeMonaco,
     FullCodePreview,
-    Preview
+    Preview,
+    Navigation
   },
 
   data() {
@@ -481,13 +500,24 @@ export default {
     },
 
     hasVersionSince() {
-      return this.exampleConfig && this.exampleConfig.since
-        && compareVersions(this.shared.echartsFullVersion, this.exampleConfig.since) >= 0;
+      return (
+        this.exampleConfig &&
+        this.exampleConfig.since &&
+        compareVersions(
+          this.shared.echartsFullVersion,
+          this.exampleConfig.since
+        ) >= 0
+      );
     },
 
     versionSinceBanner() {
-      return this.$t('editor.bannerVersionRequire') + ' v' + this.exampleConfig.since + '+';
-    },
+      return (
+        this.$t('editor.bannerVersionRequire') +
+        ' v' +
+        this.exampleConfig.since +
+        '+'
+      );
+    }
   },
 
   mounted() {
@@ -508,7 +538,10 @@ export default {
 
       window.addEventListener('mousemove', (e) => {
         if (this.draggingMouseDown) {
-          let percentage = e.clientX / window.innerWidth;
+          const main = document.getElementById('main-container');
+          const rect = main.getBoundingClientRect();
+          let x = e.clientX - rect.left;
+          let percentage = x / rect.width;
           percentage = Math.min(0.9, Math.max(0.1, percentage));
           this.leftContainerSize = percentage * 100;
         }
@@ -840,7 +873,25 @@ $control-panel-height: 30px;
 $pd-basic: 10px;
 $handler-width: 15px;
 
+.editor-workspace {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  height: 100vh;
+  > * {
+    min-height: 0;
+  }
+}
+
+.editor-nav {
+  overflow: auto;
+  height: 100%;
+}
+
 #main-container {
+  position: relative;
+  height: 100%;
+  min-height: 0;
+
   .handler {
     position: absolute;
     left: 50%;

--- a/src/editor/Editor.vue
+++ b/src/editor/Editor.vue
@@ -1,6 +1,9 @@
 <template>
   <section class="editor-workspace">
-    <Navigation @select-example="onSelectExample" :embedded="true" />
+    <Navigation
+      @select-example="onSelectExample"
+      :currentExample="exampleConfig"
+    />
     <div id="main-container" :class="{ 'is-dragging': draggingMouseDown }">
       <div
         id="editor-left-container"

--- a/src/editor/Navigation.vue
+++ b/src/editor/Navigation.vue
@@ -1,0 +1,84 @@
+<template>
+  <nav class="editor-nav container-fluid">
+    <div
+      class="navbar"
+      v-for="categoryObj in exampleList"
+      :key="categoryObj.category"
+    >
+      <ul class="nav">
+        <h3 class="chart-type-head" :id="'chart-type-' + categoryObj.category">
+          {{ $t('chartTypes.' + categoryObj.category) }}
+        </h3>
+        <li class="row" :id="'chart-row-' + categoryObj.category">
+          <div
+            class="col-1"
+            v-for="exampleItem in categoryObj.examples"
+            :key="exampleItem.id"
+          >
+            <ExampleCard :example="exampleItem" :embedded="true"></ExampleCard>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</template>
+<script>
+import {
+  buildExampleListByCategory,
+  createExampleList,
+  createLazyLoader
+} from '../common/exampleCatalogUtils.js';
+import CHART_LIST from '../data/chart-list-data';
+import CHART_LIST_GL from '../data/chart-list-data-gl';
+import ExampleCard from '../explore/ExampleCard.vue';
+
+export default {
+  components: {
+    ExampleCard
+  },
+
+  props: {},
+
+  data() {
+    return {
+      EXAMPLE_CATEGORIES: [],
+      exampleListByCategory: buildExampleListByCategory(
+        CHART_LIST,
+        CHART_LIST_GL
+      )
+    };
+  },
+
+  computed: {
+    exampleList() {
+      return createExampleList(this.exampleListByCategory);
+    }
+  },
+
+  mounted() {
+    this._lazyload = createLazyLoader();
+  }
+};
+</script>
+
+<style lang="scss">
+.editor-nav {
+  .example-link {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 10px;
+
+    .example-link-image {
+      margin-top: 0;
+      width: 72px;
+      flex: 0 0 72px;
+    }
+
+    .example-info {
+      flex: 1;
+      min-width: 0;
+    }
+  }
+}
+</style>

--- a/src/editor/Navigation.vue
+++ b/src/editor/Navigation.vue
@@ -1,35 +1,40 @@
 <template>
-  <nav class="editor-nav navbar">
-    <details
-      class="nav"
-      v-for="categoryObj in exampleList"
-      :key="categoryObj.category"
-    >
-      <summary
-        class="chart-type-head"
-        :id="'chart-type-' + categoryObj.category"
+  <section class="editor-navigation">
+    <div class="menu-button" @click="toggleNav" role="button">
+      <span :class="isNavOpen ? 'close-icon' : 'hamburger-icon'"></span>
+    </div>
+    <nav class="navbar" :class="{ 'nav-closed': !isNavOpen }">
+      <details
+        class="nav"
+        v-for="categoryObj in exampleList"
+        :key="categoryObj.category"
       >
-        {{ $t('chartTypes.' + categoryObj.category) }}
-        <span class="arrow"></span>
-      </summary>
-
-      <ul class="row" :id="'chart-row-' + categoryObj.category">
-        <li
-          class="col-xs-12"
-          :id="exampleItem.id"
-          v-for="exampleItem in categoryObj.examples"
-          :key="exampleItem.id"
-          :class="{ 'is-active': currentExample.id === exampleItem.id }"
+        <summary
+          class="chart-type-head"
+          :id="'chart-type-' + categoryObj.category"
         >
-          <ExampleCard
-            :example="exampleItem"
-            :embedded="true"
-            @select-example="onSelectExample"
-          ></ExampleCard>
-        </li>
-      </ul>
-    </details>
-  </nav>
+          {{ $t('chartTypes.' + categoryObj.category) }}
+          <span class="arrow"></span>
+        </summary>
+
+        <ul class="row" :id="'chart-row-' + categoryObj.category">
+          <li
+            class="col-xs-12"
+            :id="exampleItem.id"
+            v-for="exampleItem in categoryObj.examples"
+            :key="exampleItem.id"
+            :class="{ 'is-active': currentExample.id === exampleItem.id }"
+          >
+            <ExampleCard
+              :example="exampleItem"
+              :embedded="true"
+              @select-example="onSelectExample"
+            ></ExampleCard>
+          </li>
+        </ul>
+      </details>
+    </nav>
+  </section>
 </template>
 
 <script>
@@ -49,14 +54,15 @@ export default {
 
   props: {
     currentExample: {
-      type: String,
+      type: Object,
       required: true
     }
   },
 
   data() {
     return {
-      rawCategoryData: null
+      rawCategoryData: null,
+      isNavOpen: false
     };
   },
 
@@ -90,15 +96,17 @@ export default {
   methods: {
     onSelectExample(example) {
       this.$emit('select-example', example);
+      this.isNavOpen = false;
+    },
+    toggleNav() {
+      this.isNavOpen = !this.isNavOpen;
     },
     markExampleActive() {
       if (!this.currentExample || !this.currentExample.id) return;
       this.$nextTick(() => {
         const id = String(this.currentExample.id);
-        const exampleItems = this.$refs.exampleItems || [];
-        const exampleNode = exampleItems.find(
-          (el) => el && String(el.dataset && el.dataset.exampleId) === id
-        );
+        const exampleNode = document.getElementById(id);
+
         if (!exampleNode) return;
         const detailsElement = exampleNode.closest
           ? exampleNode.closest('details')
@@ -114,7 +122,43 @@ export default {
 </script>
 
 <style lang="scss">
-.editor-nav {
+$breakpoint-sm: 768px;
+$primary-color: #fb628b;
+$light-gray: #f0f0f0;
+$dark-gray: #666;
+$transition-speed: 0.3s;
+
+@mixin icon-bar {
+  position: absolute;
+  width: 25px;
+  height: 2px;
+  background-color: #fff;
+  transition: all $transition-speed ease-in-out;
+}
+
+.editor-navigation {
+  nav.navbar {
+    overflow: auto;
+    width: 100%;
+    height: 100%;
+
+    @media (max-width: $breakpoint-sm) {
+      position: fixed;
+      top: 0;
+      left: 0;
+      z-index: 1000;
+      background-color: #fff;
+      overflow-y: auto;
+      transform: translateX(0);
+      transition: transform $transition-speed ease-in-out;
+      padding-bottom: 20px;
+
+      &.nav-closed {
+        transform: translateX(-100%);
+      }
+    }
+  }
+
   details.nav {
     summary.chart-type-head {
       display: flex;
@@ -132,11 +176,11 @@ export default {
       }
 
       &:hover {
-        background-color: #f0f0f0;
+        background-color: $light-gray;
       }
 
       .arrow {
-        border: solid #666;
+        border: solid $dark-gray;
         border-width: 0 2px 2px 0;
         display: inline-block;
         padding: 3px;
@@ -147,7 +191,7 @@ export default {
 
     &[open] {
       summary.chart-type-head {
-        background-color: #f0f0f0;
+        background-color: $light-gray;
 
         .arrow {
           transform: rotate(-135deg) translate(-2px, -2px);
@@ -174,7 +218,7 @@ export default {
       padding: 4px;
 
       &.is-active {
-        background-color: #f0f0f0;
+        background-color: $light-gray;
       }
     }
   }
@@ -203,6 +247,65 @@ export default {
         display: none;
       }
     }
+  }
+}
+
+.menu-button {
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background-color: $primary-color;
+  color: #fff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  z-index: 1001;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+
+  @media (min-width: $breakpoint-sm) {
+    display: none;
+  }
+}
+
+.hamburger-icon,
+.close-icon {
+  position: relative;
+  width: 25px;
+  height: 2px;
+  background-color: #fff;
+  transition: all $transition-speed ease-in-out;
+
+  &::before,
+  &::after {
+    content: '';
+    @include icon-bar;
+  }
+}
+
+.hamburger-icon::before {
+  top: -8px;
+}
+
+.hamburger-icon::after {
+  top: 8px;
+}
+
+.close-icon {
+  transform: rotate(45deg);
+
+  &::before {
+    transform: rotate(90deg);
+    top: 0;
+  }
+
+  &::after {
+    transform: rotate(0deg);
+    top: 0;
+    opacity: 0;
   }
 }
 </style>

--- a/src/editor/Navigation.vue
+++ b/src/editor/Navigation.vue
@@ -16,9 +16,10 @@
       <ul class="row" :id="'chart-row-' + categoryObj.category">
         <li
           class="col-xs-12"
+          :id="exampleItem.id"
           v-for="exampleItem in categoryObj.examples"
           :key="exampleItem.id"
-          :class="{ 'is-active': currentExampleId === exampleItem.id }"
+          :class="{ 'is-active': currentExample.id === exampleItem.id }"
         >
           <ExampleCard
             :example="exampleItem"
@@ -46,12 +47,16 @@ export default {
     ExampleCard
   },
 
-  props: {},
+  props: {
+    currentExample: {
+      type: String,
+      required: true
+    }
+  },
 
   data() {
     return {
-      rawCategoryData: null,
-      currentExampleId: ''
+      rawCategoryData: null
     };
   },
 
@@ -73,6 +78,7 @@ export default {
 
   mounted() {
     this._lazyload = createLazyLoader();
+    this.markExampleActive();
   },
 
   beforeDestroy() {
@@ -83,8 +89,25 @@ export default {
 
   methods: {
     onSelectExample(example) {
-      this.currentExampleId = example.id;
       this.$emit('select-example', example);
+    },
+    markExampleActive() {
+      if (!this.currentExample || !this.currentExample.id) return;
+      this.$nextTick(() => {
+        const id = String(this.currentExample.id);
+        const exampleItems = this.$refs.exampleItems || [];
+        const exampleNode = exampleItems.find(
+          (el) => el && String(el.dataset && el.dataset.exampleId) === id
+        );
+        if (!exampleNode) return;
+        const detailsElement = exampleNode.closest
+          ? exampleNode.closest('details')
+          : null;
+        if (detailsElement) detailsElement.open = true;
+        if (exampleNode.scrollIntoView)
+          exampleNode.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        if (exampleNode.focus) exampleNode.focus();
+      });
     }
   }
 };

--- a/src/editor/Navigation.vue
+++ b/src/editor/Navigation.vue
@@ -1,27 +1,31 @@
 <template>
-  <nav class="editor-nav container-fluid">
+  <nav class="editor-nav container-fluid navbar">
     <div
-      class="navbar"
+      class="nav"
       v-for="categoryObj in exampleList"
       :key="categoryObj.category"
     >
-      <ul class="nav">
-        <h3 class="chart-type-head" :id="'chart-type-' + categoryObj.category">
-          {{ $t('chartTypes.' + categoryObj.category) }}
-        </h3>
-        <li class="row" :id="'chart-row-' + categoryObj.category">
-          <div
-            class="col-1"
-            v-for="exampleItem in categoryObj.examples"
-            :key="exampleItem.id"
-          >
-            <ExampleCard :example="exampleItem" :embedded="true"></ExampleCard>
-          </div>
+      <h3 class="chart-type-head" :id="'chart-type-' + categoryObj.category">
+        {{ $t('chartTypes.' + categoryObj.category) }}
+      </h3>
+
+      <ul class="row" :id="'chart-row-' + categoryObj.category">
+        <li
+          class="col-xs-12"
+          v-for="exampleItem in categoryObj.examples"
+          :key="exampleItem.id"
+        >
+          <ExampleCard
+            :example="exampleItem"
+            :embedded="true"
+            @select-example="onSelectExample"
+          ></ExampleCard>
         </li>
       </ul>
     </div>
   </nav>
 </template>
+
 <script>
 import {
   buildExampleListByCategory,
@@ -41,7 +45,6 @@ export default {
 
   data() {
     return {
-      EXAMPLE_CATEGORIES: [],
       exampleListByCategory: buildExampleListByCategory(
         CHART_LIST,
         CHART_LIST_GL
@@ -57,6 +60,16 @@ export default {
 
   mounted() {
     this._lazyload = createLazyLoader();
+  },
+
+  beforeDestroy() {
+    this._lazyload.destroy();
+  },
+
+  methods: {
+    onSelectExample(example) {
+      this.$emit('select-example', example);
+    }
   }
 };
 </script>
@@ -71,13 +84,17 @@ export default {
 
     .example-link-image {
       margin-top: 0;
-      width: 72px;
-      flex: 0 0 72px;
+      width: 48px;
+      flex: 0 0 48px;
     }
 
     .example-info {
       flex: 1;
       min-width: 0;
+
+      .example-version-since {
+        display: none;
+      }
     }
   }
 }

--- a/src/editor/Navigation.vue
+++ b/src/editor/Navigation.vue
@@ -1,19 +1,24 @@
 <template>
-  <nav class="editor-nav container-fluid navbar">
-    <div
+  <nav class="editor-nav navbar">
+    <details
       class="nav"
       v-for="categoryObj in exampleList"
       :key="categoryObj.category"
     >
-      <h3 class="chart-type-head" :id="'chart-type-' + categoryObj.category">
+      <summary
+        class="chart-type-head"
+        :id="'chart-type-' + categoryObj.category"
+      >
         {{ $t('chartTypes.' + categoryObj.category) }}
-      </h3>
+        <span class="arrow"></span>
+      </summary>
 
       <ul class="row" :id="'chart-row-' + categoryObj.category">
         <li
           class="col-xs-12"
           v-for="exampleItem in categoryObj.examples"
           :key="exampleItem.id"
+          :class="{ 'is-active': currentExampleId === exampleItem.id }"
         >
           <ExampleCard
             :example="exampleItem"
@@ -22,7 +27,7 @@
           ></ExampleCard>
         </li>
       </ul>
-    </div>
+    </details>
   </nav>
 </template>
 
@@ -45,17 +50,25 @@ export default {
 
   data() {
     return {
-      exampleListByCategory: buildExampleListByCategory(
-        CHART_LIST,
-        CHART_LIST_GL
-      )
+      rawCategoryData: null,
+      currentExampleId: ''
     };
   },
 
   computed: {
     exampleList() {
-      return createExampleList(this.exampleListByCategory);
+      if (!this.rawCategoryData) {
+        return [];
+      }
+      return createExampleList(this.rawCategoryData);
     }
+  },
+
+  created() {
+    this.rawCategoryData = buildExampleListByCategory(
+      CHART_LIST,
+      CHART_LIST_GL
+    );
   },
 
   mounted() {
@@ -63,11 +76,14 @@ export default {
   },
 
   beforeDestroy() {
-    this._lazyload.destroy();
+    if (this._lazyload && typeof this._lazyload.destroy === 'function') {
+      this._lazyload.destroy();
+    }
   },
 
   methods: {
     onSelectExample(example) {
+      this.currentExampleId = example.id;
       this.$emit('select-example', example);
     }
   }
@@ -76,6 +92,74 @@ export default {
 
 <style lang="scss">
 .editor-nav {
+  details.nav {
+    summary.chart-type-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 12px 16px;
+      margin: 0;
+      cursor: pointer;
+      list-style: none;
+      outline: none;
+      user-select: none;
+
+      &::-webkit-details-marker {
+        display: none;
+      }
+
+      &:hover {
+        background-color: #f0f0f0;
+      }
+
+      .arrow {
+        border: solid #666;
+        border-width: 0 2px 2px 0;
+        display: inline-block;
+        padding: 3px;
+        transform: rotate(45deg);
+        transition: transform 0.2s ease;
+      }
+    }
+
+    &[open] {
+      summary.chart-type-head {
+        background-color: #f0f0f0;
+
+        .arrow {
+          transform: rotate(-135deg) translate(-2px, -2px);
+        }
+      }
+
+      .row {
+        max-height: 100%;
+        opacity: 1;
+      }
+    }
+
+    .row {
+      list-style: none;
+      margin: 0;
+      max-height: 0;
+      overflow: hidden;
+      opacity: 0;
+      transition: max-height 0.3s cubic-bezier(0, 1, 0, 1), opacity 0.2s ease,
+        padding 0.3s ease;
+    }
+
+    li {
+      padding: 4px;
+
+      &.is-active {
+        background-color: #f0f0f0;
+      }
+    }
+  }
+
+  .example-list-item {
+    margin: 0;
+  }
+
   .example-link {
     display: flex;
     align-items: center;

--- a/src/explore/ExampleCard.vue
+++ b/src/explore/ExampleCard.vue
@@ -1,23 +1,27 @@
 <template>
   <div class="example-list-item">
-    <a target="_blank" class="example-link" :href="exampleLink">
-      <picture>
+    <a
+      class="example-link"
+      :target="embedded ? '_self' : '_blank'"
+      :href="exampleLink"
+    >
+      <picture class="example-link-image">
         <source :data-srcset="screenshotURLWebP" type="image/webp" />
         <source :data-srcset="screenshotURLPNG" type="image/png" />
         <img class="chart-area" src="../asset/placeholder.jpg" />
       </picture>
-    </a>
-    <div class="example-info">
-      <div class="example-version-since" v-if="hasVersionSince">
-        {{ versionSinceBanner }}
-      </div>
-      <div>
-        <div class="example-title" :title="title">{{ title }}</div>
-        <div v-if="showSubtitle" class="example-subtitle" :title="subtitle">
-          {{ subtitle }}
+      <div class="example-info">
+        <div class="example-version-since" v-if="hasVersionSince">
+          {{ versionSinceBanner }}
+        </div>
+        <div>
+          <div class="example-title" :title="title">{{ title }}</div>
+          <div v-if="showSubtitle" class="example-subtitle" :title="subtitle">
+            {{ subtitle }}
+          </div>
         </div>
       </div>
-    </div>
+    </a>
   </div>
 </template>
 
@@ -27,7 +31,13 @@ import { store } from '../common/store';
 import { URL_PARAMS } from '../common/config';
 
 export default {
-  props: ['example'],
+  props: {
+    example: Object,
+    embedded: {
+      type: Boolean,
+      default: false
+    }
+  },
 
   computed: {
     title() {
@@ -103,21 +113,27 @@ export default {
   position: relative;
 
   .example-link {
-    margin-top: 10px;
-    border-radius: 5px;
-    box-shadow: 0 0 20px rgba(0, 0, 0, 0.05);
-    overflow: hidden;
-    display: block;
-  }
+    text-decoration: none;
 
-  .chart-area {
-    width: 100%;
-    height: 100%;
-    cursor: pointer;
-    transition: 0.3s ease-in-out;
+    &-image {
+      margin-top: 10px;
+      border-radius: 5px;
+      box-shadow: 0 0 20px rgba(0, 0, 0, 0.05);
+      overflow: hidden;
+      display: block;
+
+      .chart-area {
+        width: 100%;
+        height: 100%;
+        cursor: pointer;
+        transition: 0.3s ease-in-out;
+      }
+    }
 
     &:hover {
-      transform: scale(1.2);
+      .chart-area {
+        transform: scale(1.2);
+      }
     }
   }
 

--- a/src/explore/ExampleCard.vue
+++ b/src/explore/ExampleCard.vue
@@ -4,6 +4,7 @@
       class="example-link"
       :target="embedded ? '_self' : '_blank'"
       :href="exampleLink"
+      @click="onLinkClick"
     >
       <picture class="example-link-image">
         <source :data-srcset="screenshotURLWebP" type="image/webp" />
@@ -98,6 +99,16 @@ export default {
 
     screenshotURLPNG() {
       return `${store.cdnRoot}/${this.exampleThumbFilePath}.png?_v_=${store.version}`;
+    }
+  },
+
+  methods: {
+    onLinkClick(event) {
+      if (!this.embedded) {
+        return;
+      }
+      event.preventDefault();
+      this.$emit('select-example', this.example);
     }
   }
 };

--- a/src/explore/Explore.vue
+++ b/src/explore/Explore.vue
@@ -68,66 +68,15 @@
 <script>
 import CHART_LIST from '../data/chart-list-data';
 import CHART_LIST_GL from '../data/chart-list-data-gl';
-import { EXAMPLE_CATEGORIES, BLACK_MAP } from '../common/config';
+import { EXAMPLE_CATEGORIES } from '../common/config';
 import { store } from '../common/store';
 import ExampleCard from './ExampleCard.vue';
-import LazyLoad from 'vanilla-lazyload/dist/lazyload.esm';
-
-const icons = {};
-
-[
-  'line',
-  'bar',
-  'scatter',
-  'pie',
-  'radar',
-  'funnel',
-  'gauge',
-  'map',
-  'graph',
-  'treemap',
-  'parallel',
-  'sankey',
-  'candlestick',
-  'boxplot',
-  'heatmap',
-  'pictorialBar',
-  'themeRiver',
-  'calendar',
-  'matrix',
-  'chord',
-  'custom',
-  'sunburst',
-  'tree',
-  'dataset',
-  'geo',
-  'lines',
-  'dataZoom',
-  'rich',
-  'graphic'
-].forEach(function (category) {
-  icons[category] = require('../asset/icon/' + category + '.svg');
-});
-
-const glIcon = require('../asset/icon/gl.svg');
-[
-  'globe',
-  'bar3D',
-  'scatter3D',
-  'surface',
-  'map3D',
-  'lines3D',
-  'line3D',
-  'scatterGL',
-  'linesGL',
-  'flowGL',
-  'graphGL',
-  'geo3D'
-].forEach(function (category) {
-  icons[category] = glIcon;
-});
-
-const LAZY_LOADED_CLASS = 'ec-shot-loaded';
+import {
+  icons,
+  createLazyLoader,
+  buildExampleListByCategory,
+  createExampleList
+} from '../common/exampleCatalogUtils.js';
 
 export default {
   components: {
@@ -135,62 +84,15 @@ export default {
   },
 
   data() {
-    const exampleListByCategory = {};
-
-    function addExamples(list, isGL) {
-      let categoryOrder = 0;
-      // Add by category order in each example.
-      do {
-        let added = false;
-        for (let i = 0; i < list.length; i++) {
-          const example = list[i];
-          if (BLACK_MAP.hasOwnProperty(example.id)) {
-            continue;
-          }
-          if (example.noExplore) {
-            continue;
-          }
-          if (typeof example.category === 'string') {
-            example.category = [example.category];
-          }
-
-          const categoryStr = (example.category || [])[categoryOrder];
-          if (categoryStr) {
-            added = true;
-            let categoryObj = exampleListByCategory[categoryStr];
-            if (!categoryObj) {
-              categoryObj = {
-                category: categoryStr,
-                examples: []
-              };
-              exampleListByCategory[categoryStr] = categoryObj;
-            }
-            example.isGL = isGL;
-
-            categoryObj.examples.push(example);
-          }
-        }
-
-        if (!added) {
-          break;
-        }
-      } while (++categoryOrder && categoryOrder < 4); // At most 4 category
-    }
-
-    addExamples(CHART_LIST, false);
-    addExamples(CHART_LIST_GL, true);
+    const exampleListByCategory = buildExampleListByCategory(
+      CHART_LIST,
+      CHART_LIST_GL
+    );
 
     return {
       shared: store,
-
       icons,
-
       EXAMPLE_CATEGORIES,
-      // [{
-      //  category: '',
-      //  isGL: false
-      //  examples: []
-      // }]
       exampleListByCategory
     };
   },
@@ -200,7 +102,7 @@ export default {
       const imgs = this.$el.querySelectorAll('img.chart-area');
       for (let i = 0; i < imgs.length; i++) {
         // Force lazyload to update
-        LazyLoad.resetStatus(imgs[i]);
+        createLazyLoader().load(imgs[i]);
       }
       this._lazyload.update();
     }
@@ -208,39 +110,12 @@ export default {
 
   computed: {
     exampleList() {
-      const list = [];
-      for (let i = 0, len = EXAMPLE_CATEGORIES.length; i < len; i++) {
-        const category = EXAMPLE_CATEGORIES[i];
-        const categoryObj = this.exampleListByCategory[category];
-        if (categoryObj && categoryObj.examples.length > 0) {
-          list.push({
-            category,
-            examples: categoryObj.examples
-          });
-        }
-      }
-      return list;
+      return createExampleList(this.exampleListByCategory);
     }
   },
 
   mounted() {
-    this._lazyload = new LazyLoad({
-      // Container should be the scroll viewport.
-      // container: this.$el.querySelector('#explore-container .example-list-panel'),
-      elements_selector: '.chart-area',
-      load_delay: 400,
-      class_loaded: LAZY_LOADED_CLASS,
-      callback_error(img) {
-        const fallbackSrc = img.src;
-        const children = img.parentElement.children;
-        for (let i = 0, len = children.length; i < len; i++) {
-          const el = children[i];
-          if (el !== img) {
-            el.srcset = fallbackSrc;
-          }
-        }
-      }
-    });
+    this._lazyload = createLazyLoader({});
 
     setTimeout(() => {
       location.hash && this.onHashChange();


### PR DESCRIPTION
- Introduced Navigation to editor for ease of traversal between examples.
- Refactored Explore component to reutilize utility in Navigation component.
- Added exampleCatalogUtils for shared logic between Explore and Navigation.
- Modified ExampleCard to be flexible with new navigation structure.

## Why?
**The Issue:** Constant back-and-forth page bouncing for viewing.
**Existing Scenario:** Currently, users have to navigate back and forth between two separate pages, the example gallery list and the code editor workspace, just to view or switch charts.
**Proposed Solution:** Embedded examples list into the editor view as a collapsible sidebar navigation panel. This enables instant example swapping using native event loops and browser URL parsing, eliminating  roundtrips.

| Before | After|
|--|--|
| <img width="1861" height="935" alt="image" src="https://github.com/user-attachments/assets/21e26a14-8de2-447b-8fb0-84e2c9f6046c" /> | <img width="1861" height="935" alt="image" src="https://github.com/user-attachments/assets/c1d4baa4-1681-485a-9895-e8ca30a151f7" /> |
|<img width="373" height="664" alt="image" src="https://github.com/user-attachments/assets/4b8b30b0-192b-4e07-8750-1ba7a1739ced" />| <img width="373" height="664" alt="image" src="https://github.com/user-attachments/assets/2358c7f4-05fa-4378-a8b3-c59b3a0ed7bf" /> <img width="373" height="664" alt="image" src="https://github.com/user-attachments/assets/1b90f462-38b2-4712-9a46-d4ba3ea030e0" /> |